### PR TITLE
feat: 연락처 추가 API 구현

### DIFF
--- a/src/main/java/org/fastcampus/jober/space/controller/SpaceContactController.java
+++ b/src/main/java/org/fastcampus/jober/space/controller/SpaceContactController.java
@@ -1,0 +1,33 @@
+package org.fastcampus.jober.space.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.fastcampus.jober.space.dto.request.ContactRequestDto;
+import org.fastcampus.jober.space.dto.response.ContactResponseDto;
+import org.fastcampus.jober.space.service.SpaceContactService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Space Contact", description = "스페이스 연락처 관리 API")
+@RestController
+@RequestMapping("/api/space")
+@RequiredArgsConstructor
+public class SpaceContactController {
+
+  private final SpaceContactService spaceContactService;
+
+  /**
+   * 스페이스에 여러 연락처를 추가하는 API
+   * 
+   * @param requestDto 연락처 추가 요청 데이터 (스페이스 ID, 연락처 목록)
+   * @return 추가된 연락처 정보와 등록 시간을 포함한 응답
+   */
+  @Operation(summary = "연락처 추가", description = "스페이스에 여러 연락처를 추가합니다.")
+  @PostMapping("/add-contact")
+  public ResponseEntity<ContactResponseDto> addContacts(
+      @RequestBody ContactRequestDto requestDto) {
+    ContactResponseDto response = spaceContactService.addContacts(requestDto);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/org/fastcampus/jober/space/dto/request/ContactRequestDto.java
+++ b/src/main/java/org/fastcampus/jober/space/dto/request/ContactRequestDto.java
@@ -1,0 +1,40 @@
+package org.fastcampus.jober.space.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "연락처 등록 요청 DTO")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactRequestDto {
+
+  @Schema(description = "스페이스 ID", example = "1")
+  private Long spaceId;
+
+  @Schema(description = "연락처 목록")
+  private List<ContactInfo> contacts;
+
+  @Schema(description = "연락처 정보")
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ContactInfo {
+
+    @Schema(description = "이름", example = "김철수")
+    private String name;
+
+    @Schema(description = "휴대전화", example = "010-1234-5678")
+    private String phoneNum;
+
+    @Schema(description = "이메일", example = "kim@example.com")
+    private String email;
+  }
+}

--- a/src/main/java/org/fastcampus/jober/space/dto/response/ContactResponseDto.java
+++ b/src/main/java/org/fastcampus/jober/space/dto/response/ContactResponseDto.java
@@ -1,0 +1,50 @@
+package org.fastcampus.jober.space.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "연락처 등록 응답 DTO")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactResponseDto {
+
+  @Schema(description = "스페이스 ID", example = "1")
+  private Long spaceId;
+
+  @Schema(description = "스페이스 이름", example = "테스트 회사")
+  private String spaceName;
+
+  @Schema(description = "등록된 연락처 목록")
+  private List<ContactInfo> contacts;
+
+  @Schema(description = "등록 시간", example = "2024-01-15T10:30:00")
+  private LocalDateTime registeredAt;
+
+  @Schema(description = "연락처 정보")
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ContactInfo {
+
+    @Schema(description = "연락처 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이름", example = "김철수")
+    private String name;
+
+    @Schema(description = "휴대전화", example = "010-1234-5678")
+    private String phoneNum;
+
+    @Schema(description = "이메일", example = "kim@example.com")
+    private String email;
+  }
+}

--- a/src/main/java/org/fastcampus/jober/space/entity/SpaceContacts.java
+++ b/src/main/java/org/fastcampus/jober/space/entity/SpaceContacts.java
@@ -1,18 +1,30 @@
 package org.fastcampus.jober.space.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SpaceContacts {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    
+    @Column(nullable = false)
     private String name;
-    private String email;
+    
+    @Column(nullable = false)
     private String phoneNum;
-
+    
+    @Column(nullable = false)
+    private String email;
+    
+    @Column(name = "space_id", nullable = false)
     private Long spaceId;
 }

--- a/src/main/java/org/fastcampus/jober/space/repository/SpaceContactsRepository.java
+++ b/src/main/java/org/fastcampus/jober/space/repository/SpaceContactsRepository.java
@@ -1,0 +1,26 @@
+package org.fastcampus.jober.space.repository;
+
+import org.fastcampus.jober.space.entity.SpaceContacts;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SpaceContactsRepository extends JpaRepository<SpaceContacts, Long> {
+    
+    /**
+     * 스페이스 ID로 연락처 목록을 조회합니다.
+     * 
+     * @param spaceId 조회할 스페이스 ID
+     * @return 해당 스페이스의 연락처 목록
+     */
+    List<SpaceContacts> findBySpaceId(Long spaceId);
+    
+    /**
+     * 스페이스 ID로 모든 연락처를 삭제합니다.
+     * 
+     * @param spaceId 삭제할 스페이스 ID
+     */
+    void deleteBySpaceId(Long spaceId);
+}

--- a/src/main/java/org/fastcampus/jober/space/service/SpaceContactService.java
+++ b/src/main/java/org/fastcampus/jober/space/service/SpaceContactService.java
@@ -1,0 +1,64 @@
+package org.fastcampus.jober.space.service;
+
+import lombok.RequiredArgsConstructor;
+import org.fastcampus.jober.space.dto.request.ContactRequestDto;
+import org.fastcampus.jober.space.dto.response.ContactResponseDto;
+import org.fastcampus.jober.space.entity.SpaceContacts;
+import org.fastcampus.jober.space.repository.SpaceContactsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SpaceContactService {
+
+  private final SpaceContactsRepository spaceContactsRepository;
+
+  /**
+   * 스페이스에 연락처를 추가하는 비즈니스 로직
+   * 
+   * 기존 연락처를 유지하면서 새로운 연락처들을 추가합니다.
+   * 트랜잭션으로 처리되어 모든 연락처 등록이 성공하거나 모두 실패합니다.
+   * 
+   * @param requestDto 연락처 추가 요청 데이터
+   * @return 추가된 연락처 정보를 포함한 응답 DTO
+   */
+  @Transactional
+  public ContactResponseDto addContacts(ContactRequestDto requestDto) {
+    // 새로운 연락처들 저장 (기존 연락처는 유지)
+    List<SpaceContacts> contacts = requestDto.getContacts().stream()
+        .map(contactInfo -> SpaceContacts.builder()
+            .name(contactInfo.getName())
+            .phoneNum(contactInfo.getPhoneNum())
+            .email(contactInfo.getEmail())
+            .spaceId(requestDto.getSpaceId())
+            .build())
+        .collect(Collectors.toList());
+
+    List<SpaceContacts> savedContacts = spaceContactsRepository.saveAll(contacts);
+
+    // 전체 연락처 목록 조회 (기존 + 새로 추가된 연락처)
+    List<SpaceContacts> allContacts = spaceContactsRepository.findBySpaceId(requestDto.getSpaceId());
+
+    // 응답 DTO 생성
+    List<ContactResponseDto.ContactInfo> contactInfos = allContacts.stream()
+        .map(contact -> ContactResponseDto.ContactInfo.builder()
+            .id(contact.getId())
+            .name(contact.getName())
+            .phoneNum(contact.getPhoneNum())
+            .email(contact.getEmail())
+            .build())
+        .collect(Collectors.toList());
+
+    return ContactResponseDto.builder()
+        .spaceId(requestDto.getSpaceId())
+        .contacts(contactInfos)
+        .registeredAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/org/fastcampus/jober/space/controller/SpaceContactControllerTest.java
+++ b/src/test/java/org/fastcampus/jober/space/controller/SpaceContactControllerTest.java
@@ -1,0 +1,103 @@
+package org.fastcampus.jober.space.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fastcampus.jober.space.dto.request.ContactRequestDto;
+import org.fastcampus.jober.space.dto.response.ContactResponseDto;
+import org.fastcampus.jober.space.service.SpaceContactService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SpaceContactController.class)
+class SpaceContactControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private SpaceContactService spaceContactService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private ContactRequestDto requestDto;
+  private ContactResponseDto responseDto;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 요청 데이터 설정
+    ContactRequestDto.ContactInfo contactInfo = ContactRequestDto.ContactInfo.builder()
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .build();
+
+    requestDto = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList(contactInfo))
+        .build();
+
+    // 테스트용 응답 데이터 설정
+    ContactResponseDto.ContactInfo responseContactInfo = ContactResponseDto.ContactInfo.builder()
+        .id(1L)
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .build();
+
+    responseDto = ContactResponseDto.builder()
+        .spaceId(1L)
+        .spaceName("테스트 회사")
+        .contacts(Arrays.asList(responseContactInfo))
+        .registeredAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("연락처 등록 API 테스트 - 성공")
+  void addContacts_Success() throws Exception {
+    // given
+    when(spaceContactService.addContacts(any(ContactRequestDto.class)))
+        .thenReturn(responseDto);
+
+    // when & then
+    mockMvc.perform(post("/api/space/add-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.spaceId").value(1))
+        .andExpect(jsonPath("$.contacts[0].name").value("김철수"))
+        .andExpect(jsonPath("$.contacts[0].phoneNum").value("010-1234-5678"))
+        .andExpect(jsonPath("$.contacts[0].email").value("kim@example.com"));
+  }
+
+  @Test
+  @DisplayName("연락처 등록 API 테스트 - 잘못된 요청")
+  void addContacts_BadRequest() throws Exception {
+    // given
+    ContactRequestDto invalidRequest = ContactRequestDto.builder()
+        .spaceId(null)
+        .contacts(null)
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/space/add-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidRequest)))
+        .andExpect(status().isOk()); // validation이 없으므로 200 OK 반환
+  }
+}

--- a/src/test/java/org/fastcampus/jober/space/integration/SpaceContactIntegrationTest.java
+++ b/src/test/java/org/fastcampus/jober/space/integration/SpaceContactIntegrationTest.java
@@ -1,0 +1,142 @@
+package org.fastcampus.jober.space.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fastcampus.jober.space.dto.request.ContactRequestDto;
+import org.fastcampus.jober.space.dto.response.ContactResponseDto;
+import org.fastcampus.jober.space.entity.SpaceContacts;
+import org.fastcampus.jober.space.repository.SpaceContactsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class SpaceContactIntegrationTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @Autowired
+  private SpaceContactsRepository spaceContactsRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  @DisplayName("연락처 추가 통합 테스트 - 성공")
+  void addContacts_Integration_Success() throws Exception {
+    // given
+    ContactRequestDto.ContactInfo contactInfo1 = ContactRequestDto.ContactInfo.builder()
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .build();
+
+    ContactRequestDto.ContactInfo contactInfo2 = ContactRequestDto.ContactInfo.builder()
+        .name("이영희")
+        .phoneNum("010-9876-5432")
+        .email("lee@example.com")
+        .build();
+
+    ContactRequestDto requestDto = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList(contactInfo1, contactInfo2))
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/space/add-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.spaceId").value(1))
+        .andExpect(jsonPath("$.contacts").isArray())
+        .andExpect(jsonPath("$.contacts.length()").value(2))
+        .andExpect(jsonPath("$.contacts[0].name").value("김철수"))
+        .andExpect(jsonPath("$.contacts[1].name").value("이영희"))
+        .andExpect(jsonPath("$.registeredAt").exists());
+
+    // 데이터베이스 검증
+    assertThat(spaceContactsRepository.findBySpaceId(1L)).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("연락처 추가 통합 테스트 - 기존 연락처 유지")
+  void addContacts_Integration_KeepExisting() throws Exception {
+    // given - 기존 연락처 생성
+    SpaceContacts existingContact = SpaceContacts.builder()
+        .name("기존연락처")
+        .phoneNum("010-0000-0000")
+        .email("existing@example.com")
+        .spaceId(1L)
+        .build();
+    spaceContactsRepository.save(existingContact);
+
+    // 새로운 연락처 요청
+    ContactRequestDto.ContactInfo newContactInfo = ContactRequestDto.ContactInfo.builder()
+        .name("새연락처")
+        .phoneNum("010-1111-1111")
+        .email("new@example.com")
+        .build();
+
+    ContactRequestDto requestDto = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList(newContactInfo))
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/space/add-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.contacts.length()").value(2)); // 기존 1개 + 새로 추가된 1개
+
+    // 데이터베이스 검증 - 기존 연락처가 유지되고 새로운 연락처가 추가됨
+    assertThat(spaceContactsRepository.findBySpaceId(1L)).hasSize(2);
+    List<SpaceContacts> allContacts = spaceContactsRepository.findBySpaceId(1L);
+    assertThat(allContacts).extracting("name").containsExactlyInAnyOrder("기존연락처", "새연락처");
+  }
+
+  @Test
+  @DisplayName("연락처 추가 통합 테스트 - 빈 연락처 목록")
+  void addContacts_Integration_EmptyContacts() throws Exception {
+    // given
+    ContactRequestDto requestDto = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList())
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/space/add-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.contacts").isArray())
+        .andExpect(jsonPath("$.contacts.length()").value(0));
+
+    // 데이터베이스 검증
+    assertThat(spaceContactsRepository.findBySpaceId(1L)).isEmpty();
+  }
+}

--- a/src/test/java/org/fastcampus/jober/space/repository/SpaceContactsRepositoryTest.java
+++ b/src/test/java/org/fastcampus/jober/space/repository/SpaceContactsRepositoryTest.java
@@ -1,0 +1,123 @@
+package org.fastcampus.jober.space.repository;
+
+import org.fastcampus.jober.space.entity.SpaceContacts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class SpaceContactsRepositoryTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private SpaceContactsRepository spaceContactsRepository;
+
+  private SpaceContacts contact1;
+  private SpaceContacts contact2;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 연락처 데이터 생성
+    contact1 = SpaceContacts.builder()
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .spaceId(1L)
+        .build();
+
+    contact2 = SpaceContacts.builder()
+        .name("이영희")
+        .phoneNum("010-9876-5432")
+        .email("lee@example.com")
+        .spaceId(1L)
+        .build();
+  }
+
+  @Test
+  @DisplayName("스페이스 ID로 연락처 조회 테스트")
+  void findBySpaceId_Success() {
+    // given
+    entityManager.persistAndFlush(contact1);
+    entityManager.persistAndFlush(contact2);
+
+    // when
+    List<SpaceContacts> foundContacts = spaceContactsRepository.findBySpaceId(1L);
+
+    // then
+    assertThat(foundContacts).hasSize(2);
+    assertThat(foundContacts).extracting("name")
+        .containsExactlyInAnyOrder("김철수", "이영희");
+  }
+
+  @Test
+  @DisplayName("스페이스 ID로 연락처 삭제 테스트")
+  void deleteBySpaceId_Success() {
+    // given
+    entityManager.persistAndFlush(contact1);
+    entityManager.persistAndFlush(contact2);
+
+    // when
+    spaceContactsRepository.deleteBySpaceId(1L);
+
+    // then
+    List<SpaceContacts> remainingContacts = spaceContactsRepository.findBySpaceId(1L);
+    assertThat(remainingContacts).isEmpty();
+  }
+
+  @Test
+  @DisplayName("연락처 저장 테스트")
+  void save_Success() {
+    // given
+    SpaceContacts newContact = SpaceContacts.builder()
+        .name("박민수")
+        .phoneNum("010-5555-1234")
+        .email("park@example.com")
+        .spaceId(2L)
+        .build();
+
+    // when
+    SpaceContacts savedContact = spaceContactsRepository.save(newContact);
+
+    // then
+    assertThat(savedContact.getId()).isNotNull();
+    assertThat(savedContact.getName()).isEqualTo("박민수");
+    assertThat(savedContact.getSpaceId()).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("다른 스페이스의 연락처는 삭제되지 않음 테스트")
+  void deleteBySpaceId_OtherSpaceContactsNotDeleted() {
+    // given
+    SpaceContacts contact3 = SpaceContacts.builder()
+        .name("박민수")
+        .phoneNum("010-5555-1234")
+        .email("park@example.com")
+        .spaceId(2L)
+        .build();
+
+    entityManager.persistAndFlush(contact1);
+    entityManager.persistAndFlush(contact2);
+    entityManager.persistAndFlush(contact3);
+
+    // when
+    spaceContactsRepository.deleteBySpaceId(1L);
+
+    // then
+    List<SpaceContacts> space1Contacts = spaceContactsRepository.findBySpaceId(1L);
+    List<SpaceContacts> space2Contacts = spaceContactsRepository.findBySpaceId(2L);
+
+    assertThat(space1Contacts).isEmpty();
+    assertThat(space2Contacts).hasSize(1);
+    assertThat(space2Contacts.get(0).getName()).isEqualTo("박민수");
+  }
+}

--- a/src/test/java/org/fastcampus/jober/space/service/SpaceContactServiceTest.java
+++ b/src/test/java/org/fastcampus/jober/space/service/SpaceContactServiceTest.java
@@ -1,0 +1,139 @@
+package org.fastcampus.jober.space.service;
+
+import org.fastcampus.jober.space.dto.request.ContactRequestDto;
+import org.fastcampus.jober.space.dto.response.ContactResponseDto;
+import org.fastcampus.jober.space.entity.SpaceContacts;
+import org.fastcampus.jober.space.repository.SpaceContactsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SpaceContactServiceTest {
+
+  @Mock
+  private SpaceContactsRepository spaceContactsRepository;
+
+  @InjectMocks
+  private SpaceContactService spaceContactService;
+
+  private ContactRequestDto requestDto;
+  private List<SpaceContacts> savedContacts;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 요청 데이터 설정
+    ContactRequestDto.ContactInfo contactInfo1 = ContactRequestDto.ContactInfo.builder()
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .build();
+
+    ContactRequestDto.ContactInfo contactInfo2 = ContactRequestDto.ContactInfo.builder()
+        .name("이영희")
+        .phoneNum("010-9876-5432")
+        .email("lee@example.com")
+        .build();
+
+    requestDto = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList(contactInfo1, contactInfo2))
+        .build();
+
+    // 테스트용 저장된 연락처 데이터 설정
+    SpaceContacts savedContact1 = SpaceContacts.builder()
+        .id(1L)
+        .name("김철수")
+        .phoneNum("010-1234-5678")
+        .email("kim@example.com")
+        .spaceId(1L)
+        .build();
+
+    SpaceContacts savedContact2 = SpaceContacts.builder()
+        .id(2L)
+        .name("이영희")
+        .phoneNum("010-9876-5432")
+        .email("lee@example.com")
+        .spaceId(1L)
+        .build();
+
+    savedContacts = Arrays.asList(savedContact1, savedContact2);
+  }
+
+  @Test
+  @DisplayName("연락처 추가 테스트 - 성공")
+  void addContacts_Success() {
+    // given
+    when(spaceContactsRepository.saveAll(any())).thenReturn(savedContacts);
+    when(spaceContactsRepository.findBySpaceId(1L)).thenReturn(savedContacts);
+
+    // when
+    ContactResponseDto result = spaceContactService.addContacts(requestDto);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getSpaceId()).isEqualTo(1L);
+    assertThat(result.getContacts()).hasSize(2);
+    assertThat(result.getContacts().get(0).getName()).isEqualTo("김철수");
+    assertThat(result.getContacts().get(1).getName()).isEqualTo("이영희");
+    assertThat(result.getRegisteredAt()).isNotNull();
+
+    // verify
+    verify(spaceContactsRepository, times(1)).saveAll(any());
+    verify(spaceContactsRepository, times(1)).findBySpaceId(1L);
+  }
+
+  @Test
+  @DisplayName("연락처 추가 테스트 - 빈 연락처 목록")
+  void addContacts_EmptyContacts() {
+    // given
+    ContactRequestDto emptyRequest = ContactRequestDto.builder()
+        .spaceId(1L)
+        .contacts(Arrays.asList())
+        .build();
+
+    when(spaceContactsRepository.saveAll(any())).thenReturn(Arrays.asList());
+    when(spaceContactsRepository.findBySpaceId(1L)).thenReturn(Arrays.asList());
+
+    // when
+    ContactResponseDto result = spaceContactService.addContacts(emptyRequest);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getSpaceId()).isEqualTo(1L);
+    assertThat(result.getContacts()).isEmpty();
+
+    // verify
+    verify(spaceContactsRepository, times(1)).saveAll(any());
+    verify(spaceContactsRepository, times(1)).findBySpaceId(1L);
+  }
+
+  @Test
+  @DisplayName("연락처 추가 테스트 - 기존 연락처 유지 확인")
+  void addContacts_VerifyKeepExistingContacts() {
+    // given
+    when(spaceContactsRepository.saveAll(any())).thenReturn(savedContacts);
+    when(spaceContactsRepository.findBySpaceId(1L)).thenReturn(savedContacts);
+
+    // when
+    spaceContactService.addContacts(requestDto);
+
+    // then
+    verify(spaceContactsRepository, times(1)).saveAll(any());
+    verify(spaceContactsRepository, times(1)).findBySpaceId(1L);
+    verify(spaceContactsRepository, never()).deleteBySpaceId(anyLong());
+  }
+}


### PR DESCRIPTION
## PR 종류
- [ ] 기능 개선
- [X] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
1. 새로운 기능 추가
  연락처 관리 API 구현: 스페이스별 연락처 추가 기능
  엔드포인트: POST /api/space/add-contact
  기능: 여러 연락처를 한 번에 추가 (이름, 휴대전화, 이메일)

2. 모듈화: 연락처 관련 기능을 별도 Controller/Service로 분리
  SpaceContactController.java - 연락처 API 처리
  SpaceContactService.java - 연락처 비즈니스 로직

새로 생성된 파일
  src/main/java/org/fastcampus/jober/space/
  ├── controller/SpaceContactController.java
  ├── service/SpaceContactService.java
  ├── repository/SpaceContactsRepository.java
  ├── entity/SpaceContacts.java
  ├── dto/request/ContactRequestDto.java
  └── dto/response/ContactResponseDto.java

## 관련 이슈- 관련된 이슈 번호를 적어주세요 (#issue_number)

## 체크리스트
- [X] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [X] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?

1. 단위 테스트
  SpaceContactControllerTest.java - Controller 계층 테스트
  SpaceContactServiceTest.java - Service 계층 테스트
  SpaceContactsRepositoryTest.java - Repository 계층 테스트
2. 통합 테스트
  SpaceContactIntegrationTest.java - 전체 API 플로우 테스트
3. 테스트 커버리지
  ✅ 성공 케이스: 정상적인 연락처 추가
  ✅ 기존 연락처 유지: 추가 방식 동작 확인
  ✅ 빈 연락처 목록: 빈 배열 처리
  ✅ 잘못된 요청: validation 없이 처리

## 스크린샷
필요한 경우 스크린샷을 첨부해주세요.

<img width="1420" height="757" alt="image" src="https://github.com/user-attachments/assets/5849cc35-acd8-4a32-a52a-9a0f43336083" />
<img width="1418" height="852" alt="image" src="https://github.com/user-attachments/assets/ea1baab1-11e6-4dff-9c49-3048a0bdb02a" />
<img width="365" height="268" alt="image" src="https://github.com/user-attachments/assets/e148a32d-3d13-463e-bc33-448a50537fe0" />



## 기타
추가로 알려야 할 사항이 있다면 적어주세요.

Validation 제거: 사용자 요청에 따라 @Valid 및 관련 검증 로직 제거
Space 존재 여부 검증 제거: 단순화를 위해 Space 엔티티 존재 여부 확인 로직 제거
