### PR TITLE
AI 서버 연동 개선 및 TemplateState 필드 확장

### DIFF
--- a/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
+++ b/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+import org.fastcampus.jober.template.dto.response.TemplateCreateResponseDto;
 import org.fastcampus.jober.template.dto.response.TemplateDetailResponseDto;
 import org.fastcampus.jober.template.dto.response.TemplateTitleResponseDto;
 import org.fastcampus.jober.template.service.TemplateService;
@@ -125,24 +126,29 @@ public class TemplateController {
      /**
      * AI를 통한 템플릿 생성 요청 API
      * 사용자의 메시지를 받아서 AI Flask 서버로 전달하고, 
-     * 생성된 템플릿 내용을 반환합니다.
+     * 구조화된 템플릿 응답을 반환합니다.
      * 
      * @param request 템플릿 생성 요청 DTO (사용자 메시지와 AI 세션 상태 포함)
-     * @return AI가 생성한 템플릿 내용 (Object 형태)
+     * @return AI가 생성한 구조화된 템플릿 응답 DTO
      */
     @Operation(
         summary = "AI 템플릿 생성 요청", 
         description = "사용자 메시지를 기반으로 AI가 템플릿을 생성합니다. " +
-                     "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하는 중간다리 역할을 합니다."
+                     "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하고 구조화된 응답을 반환합니다."
+    )
+    @ApiResponse(
+        responseCode = "200", 
+        description = "AI 템플릿 생성 성공",
+        content = @Content(schema = @Schema(implementation = TemplateCreateResponseDto.class))
     )
     @PostMapping("/create-template")
-    public ResponseEntity<Object> createTemplate(
+    public ResponseEntity<TemplateCreateResponseDto> createTemplate(
             @org.springframework.web.bind.annotation.RequestBody TemplateCreateRequestDto request) {
         
         log.info("템플릿 생성 요청 수신 - 사용자 메시지: {}, state: {}", request.getMessage(), request.getState());
         
         // TemplateService를 통해 AI Flask 서버로 요청 전달
-        Object aiResponse = templateService.createTemplate(request);
+        TemplateCreateResponseDto aiResponse = templateService.createTemplate(request);
         
         log.info("AI Flask 서버로부터 응답 수신 완료");
         

--- a/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
+++ b/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
@@ -27,6 +27,30 @@ public class TemplateState {
     @Schema(description = "최초 사용자 요청", example = "마케팅용 카카오톡 템플릿 만들기")
     private String originalRequest;
     
+    @JsonProperty("selected_style")
+    @Schema(description = "사용자가 선택한 템플릿 스타일", example = "기본형")
+    private String selectedStyle;
+    
+    @JsonProperty("selected_template")
+    @Schema(description = "사용자가 선택한 유사 템플릿 내용")
+    private String selectedTemplate;
+    
+    @JsonProperty("validation_result")
+    @Schema(description = "템플릿 검증 결과")
+    private Map<String, Object> validationResult;
+    
+    @JsonProperty("correction_attempts")
+    @Schema(description = "템플릿 수정 시도 횟수", example = "0")
+    private Integer correctionAttempts;
+    
+    @JsonProperty("next_action")
+    @Schema(description = "다음 수행할 액션", example = "awaiting_confirmation")
+    private String nextAction;
+    
+    @JsonProperty("template_pipeline_state")
+    @Schema(description = "템플릿 생성 파이프라인의 세부 상태")
+    private Map<String, Object> templatePipelineState;
+    
     /**
      * AI Flask 서버가 기대하는 Map 형태로 변환합니다.
      * 
@@ -36,6 +60,12 @@ public class TemplateState {
         Map<String, Object> stateMap = new HashMap<>();
         stateMap.put("step", this.step);
         stateMap.put("original_request", this.originalRequest);
+        stateMap.put("selected_style", this.selectedStyle);
+        stateMap.put("selected_template", this.selectedTemplate);
+        stateMap.put("validation_result", this.validationResult);
+        stateMap.put("correction_attempts", this.correctionAttempts);
+        stateMap.put("next_action", this.nextAction);
+        stateMap.put("template_pipeline_state", this.templatePipelineState);
         return stateMap;
     }
 }

--- a/src/main/java/org/fastcampus/jober/template/dto/response/TemplateCreateResponseDto.java
+++ b/src/main/java/org/fastcampus/jober/template/dto/response/TemplateCreateResponseDto.java
@@ -1,0 +1,53 @@
+package org.fastcampus.jober.template.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.fastcampus.jober.template.dto.request.TemplateState;
+
+import java.util.List;
+
+/**
+ * AI 서버로부터의 템플릿 생성 응답을 담는 DTO 클래스
+ * AI Flask 서버의 구조화된 응답을 프론트엔드로 전달합니다.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "AI 템플릿 생성 응답 DTO")
+public class TemplateCreateResponseDto {
+    
+    @JsonProperty("message")
+    @Schema(description = "AI 응답 메시지", example = "템플릿을 생성했습니다.")
+    private String message;
+    
+    @JsonProperty("state")
+    @Schema(description = "업데이트된 AI 세션 상태 정보")
+    private TemplateState state;
+    
+    @JsonProperty("templateContent")
+    @Schema(description = "생성된 템플릿 내용")
+    private String templateContent;
+    
+    @JsonProperty("templateOptions")
+    @Schema(description = "템플릿 선택 옵션들")
+    private List<String> templateOptions;
+    
+    @JsonProperty("htmlPreview")
+    @Schema(description = "템플릿 HTML 미리보기")
+    private String htmlPreview;
+    
+    @JsonProperty("finalTemplate")
+    @Schema(description = "최종 템플릿 내용")
+    private String finalTemplate;
+    
+    @JsonProperty("parameterizedTemplate")
+    @Schema(description = "매개변수화된 템플릿")
+    private String parameterizedTemplate;
+    
+    @JsonProperty("extractedVariables")
+    @Schema(description = "추출된 변수들")
+    private String extractedVariables;
+}

--- a/src/main/java/org/fastcampus/jober/template/service/TemplateService.java
+++ b/src/main/java/org/fastcampus/jober/template/service/TemplateService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.jober.error.BusinessException;
 import org.fastcampus.jober.error.ErrorCode;
 import org.fastcampus.jober.template.dto.request.TemplateCreateRequestDto;
+import org.fastcampus.jober.template.dto.response.TemplateCreateResponseDto;
 import org.fastcampus.jober.template.dto.response.TemplateDetailResponseDto;
 import org.fastcampus.jober.template.dto.response.TemplateTitleResponseDto;
 import org.fastcampus.jober.template.entity.Template;
@@ -15,8 +16,11 @@ import org.fastcampus.jober.util.ExternalApiUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fastcampus.jober.template.dto.request.TemplateState;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 템플릿 관련 비즈니스 로직을 처리하는 서비스 클래스
@@ -30,6 +34,7 @@ public class TemplateService {
 
     private final ExternalApiUtil externalApiUtil;
     private final TemplateRepository templateRepository;
+    private final ObjectMapper objectMapper;
 
     /**
      * AI Flask 서버의 기본 URL
@@ -49,10 +54,10 @@ public class TemplateService {
      * 템플릿 생성 요청을 기반으로 AI가 템플릿을 생성하도록 요청합니다.
      *
      * @param request 템플릿 생성 요청 DTO (사용자 메시지와 세션 상태 포함)
-     * @return AI가 생성한 템플릿 내용 (Object 형태)
+     * @return AI가 생성한 구조화된 템플릿 응답 DTO
      * @throws RuntimeException AI 서버 통신 실패 시 발생
      */
-    public Object createTemplate(TemplateCreateRequestDto request) {
+    public TemplateCreateResponseDto createTemplate(TemplateCreateRequestDto request) {
         // AI Flask 서버로 보낼 URL 구성
         String url = aiFlaskBaseUrl + aiFlaskChatEndpoint;
 
@@ -61,7 +66,81 @@ public class TemplateService {
         Object requestBody = request.toRequestBody();
 
         // ExternalApiUtil을 통해 AI Flask 서버로 요청 전송
-        return externalApiUtil.postJson(url, requestBody, Object.class, "AI Flask 서버");
+        Object aiResponse = externalApiUtil.postJson(url, requestBody, Object.class, "AI Flask 서버");
+        
+        // AI 응답을 구조화된 DTO로 파싱
+        return parseAiResponse(aiResponse);
+    }
+    
+    /**
+     * AI 서버의 원시 응답을 TemplateCreateResponseDto로 파싱합니다.
+     * 
+     * @param aiResponse AI 서버의 원시 응답
+     * @return 구조화된 템플릿 생성 응답 DTO
+     */
+    private TemplateCreateResponseDto parseAiResponse(Object aiResponse) {
+        try {
+            // Object를 Map으로 변환
+            @SuppressWarnings("unchecked")
+            Map<String, Object> responseMap = objectMapper.convertValue(aiResponse, Map.class);
+            
+            log.info("AI 서버 응답 파싱 시작: {}", responseMap);
+            
+            TemplateCreateResponseDto response = new TemplateCreateResponseDto();
+            
+            // AI 서버 실제 응답 구조에 맞게 파싱
+            response.setMessage((String) responseMap.get("response"));  // "response" 필드가 메시지
+            response.setTemplateContent((String) responseMap.get("template"));  // "template" 필드
+            response.setHtmlPreview((String) responseMap.get("htmlPreview"));
+            response.setFinalTemplate((String) responseMap.get("structured_template"));  // "structured_template"
+            response.setParameterizedTemplate((String) responseMap.get("parameterizedTemplate"));
+            
+            // editable_variables를 JSON 문자열로 변환
+            Object editableVars = responseMap.get("editable_variables");
+            if (editableVars != null) {
+                response.setExtractedVariables(objectMapper.writeValueAsString(editableVars));
+            }
+            
+            // options 파싱 (AI 서버에서 "options" 필드로 보냄)
+            @SuppressWarnings("unchecked")
+            List<String> options = (List<String>) responseMap.get("options");
+            response.setTemplateOptions(options);
+            
+            // AI 응답의 state 정보 파싱
+            @SuppressWarnings("unchecked")
+            Map<String, Object> aiStateMap = (Map<String, Object>) responseMap.get("state");
+            
+            TemplateState state = new TemplateState();
+            
+            if (aiStateMap != null) {
+                // AI state에서 직접 정보 추출
+                state.setNextAction((String) aiStateMap.get("next_action"));
+                
+                // template_pipeline_state에서 상세 정보 추출
+                @SuppressWarnings("unchecked")
+                Map<String, Object> pipelineState = (Map<String, Object>) aiStateMap.get("template_pipeline_state");
+                state.setTemplatePipelineState(pipelineState);
+                
+                if (pipelineState != null) {
+                    state.setOriginalRequest((String) pipelineState.get("original_request"));
+                }
+            }
+            
+            response.setState(state);
+            
+            log.info("AI 응답 파싱 완료: message={}, next_action={}, original_request={}", 
+                response.getMessage(), 
+                state.getNextAction(), 
+                state.getOriginalRequest());
+            
+            return response;
+        } catch (Exception e) {
+            log.error("AI 응답 파싱 실패: {}", e.getMessage(), e);
+            // 파싱 실패 시 기본 응답 반환
+            TemplateCreateResponseDto fallbackResponse = new TemplateCreateResponseDto();
+            fallbackResponse.setMessage("AI 응답 처리 중 오류가 발생했습니다.");
+            return fallbackResponse;
+        }
     }
 
     /**

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -35,7 +35,7 @@ logging:
 # AI Flask 서버 설정
 ai:
   flask:
-    base-url: http://15.164.102.187:8000  # AI Flask 서버 URL (추후 실제 URL로 변경)
+    base-url: http://13.209.3.58:8000  # AI Flask 서버 URL (추후 실제 URL로 변경)
     chat-endpoint: /api/chat  # AI 채팅 API 엔드포인트
 
 security:

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -39,7 +39,7 @@ logging:
 # AI Flask 서버 설정
 ai:
   flask:
-    base-url: http://15.164.102.187:8000  # AI Flask 서버 URL (추후 실제 URL로 변경)
+    base-url: http://13.209.3.58:8000  # AI Flask 서버 URL (추후 실제 URL로 변경)
     chat-endpoint: /api/chat  # AI 채팅 API 엔드포인트
 
 security:


### PR DESCRIPTION
## PR 종류
- [X] 기능 개선
- [ ] 새로운 기능
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
1. TemplateState DTO 확장
기존 2개 필드 → 7개 필드로 확장(AI 대화 플로우 전체 상태 관리 지원)
Map<String, Object> 타입으로 유연한 확장성 확보

2. 새로운 응답 DTO 추가
TemplateCreateResponseDto 클래스 신규 생성
기존 Object 반환 → 구조화된 DTO 반환으로 개선(타입 안전성 및 API 명세 명확화)


## 관련 이슈- 관련된 이슈 번호를 적어주세요
#16 - AI 팀 요청: TemplateState 필드 확장

## 체크리스트- [ ] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [X] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="702" height="862" alt="스크린샷 2025-09-11 오후 3 41 30" src="https://github.com/user-attachments/assets/cfc876b4-c11b-49a7-b7dc-b990739b10e2" />

## 기타
타입 안정성: Object → 구조화된 DTO로 컴파일 타임 체크 가능
확장성: Map<String, Object> 타입으로 AI 응답 구조 변경에 유연 대응
안정성: 방어적 프로그래밍으로 null 안전성 확보