### PR TITLE
TemplateState.toMap() 메서드 개선(null 체크 후 AI 서버 전송) 

### DIFF
--- a/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
+++ b/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
@@ -50,19 +50,37 @@ public class TemplateState {
 
   /**
    * AI Flask 서버가 기대하는 Map 형태로 변환합니다.
+   * 하위 호환성을 보장하기 위해 기존 필드는 기본값으로, 새 필드는 null이 아닐 때만 포함합니다.
    *
    * @return Map 형태의 상태 정보
    */
   public Map<String, Object> toMap() {
     Map<String, Object> stateMap = new HashMap<>();
-    stateMap.put("step", this.step);
-    stateMap.put("original_request", this.originalRequest);
-    stateMap.put("selected_style", this.selectedStyle);
-    stateMap.put("selected_template", this.selectedTemplate);
-    stateMap.put("validation_result", this.validationResult);
-    stateMap.put("correction_attempts", this.correctionAttempts);
-    stateMap.put("next_action", this.nextAction);
-    stateMap.put("template_pipeline_state", this.templatePipelineState);
+
+    // 기존 필드 (하위 호환성 보장 - 기본값 제공)
+    stateMap.put("step", this.step != null ? this.step : "initial");
+    stateMap.put("original_request", this.originalRequest != null ? this.originalRequest : "");
+
+    // 새 필드들 (null이 아닐 때만 추가 - AI 서버 에러 방지)
+    if (this.selectedStyle != null) {
+      stateMap.put("selected_style", this.selectedStyle);
+    }
+    if (this.selectedTemplate != null) {
+      stateMap.put("selected_template", this.selectedTemplate);
+    }
+    if (this.validationResult != null) {
+      stateMap.put("validation_result", this.validationResult);
+    }
+    if (this.correctionAttempts != null) {
+      stateMap.put("correction_attempts", this.correctionAttempts);
+    }
+    if (this.nextAction != null) {
+      stateMap.put("next_action", this.nextAction);
+    }
+    if (this.templatePipelineState != null) {
+      stateMap.put("template_pipeline_state", this.templatePipelineState);
+    }
+
     return stateMap;
   }
 }

--- a/src/main/java/org/fastcampus/jober/template/service/TemplateService.java
+++ b/src/main/java/org/fastcampus/jober/template/service/TemplateService.java
@@ -72,6 +72,7 @@ public class TemplateService {
 
   /**
    * AI 서버의 원시 응답을 TemplateCreateResponseDto로 파싱합니다.
+   * 안전한 타입 캐스팅과 null 처리를 통해 파싱 오류를 방지합니다.
    *
    * @param aiResponse AI 서버의 원시 응답
    * @return 구조화된 템플릿 생성 응답 DTO
@@ -86,62 +87,107 @@ public class TemplateService {
 
       TemplateCreateResponseDto response = new TemplateCreateResponseDto();
 
-      // AI 서버 실제 응답 구조에 맞게 파싱
-      response.setMessage((String) responseMap.get("response")); // "response" 필드가 메시지
-      response.setTemplateContent((String) responseMap.get("template")); // "template" 필드
-      response.setHtmlPreview((String) responseMap.get("htmlPreview"));
-      response.setFinalTemplate(
-          (String) responseMap.get("structured_template")); // "structured_template"
-      response.setParameterizedTemplate((String) responseMap.get("parameterizedTemplate"));
+      // 안전한 문자열 추출 (null 처리 포함)
+      response.setMessage(safeGetString(responseMap, "response"));
+      response.setTemplateContent(safeGetString(responseMap, "template"));
+      response.setHtmlPreview(safeGetString(responseMap, "htmlPreview"));
+      response.setFinalTemplate(safeGetString(responseMap, "structured_template"));
+      response.setParameterizedTemplate(safeGetString(responseMap, "parameterizedTemplate"));
 
-      // editable_variables를 JSON 문자열로 변환
-      Object editableVars = responseMap.get("editable_variables");
-      if (editableVars != null) {
-        response.setExtractedVariables(objectMapper.writeValueAsString(editableVars));
+      // 안전한 JSON 변환
+      response.setExtractedVariables(safeConvertToJson(responseMap, "editable_variables"));
+
+      // 안전한 리스트 추출
+      response.setTemplateOptions(safeGetStringList(responseMap, "options"));
+
+      // 안전한 state 파싱
+      response.setState(safeParseState(responseMap, "state"));
+
+      log.info("AI 응답 파싱 완료: message={}", response.getMessage());
+      return response;
+
+    } catch (Exception e) {
+      log.error("AI 응답 파싱 실패: {}", e.getMessage(), e);
+      return createFallbackResponse();
+    }
+  }
+
+  /**
+   * Map에서 문자열 값을 안전하게 추출합니다.
+   */
+  private String safeGetString(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    return value != null ? value.toString() : null;
+  }
+
+  /**
+   * Map에서 JSON 변환을 안전하게 수행합니다.
+   */
+  private String safeConvertToJson(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    if (value == null) return null;
+
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (Exception e) {
+      log.warn("JSON 변환 실패 - key: {}, value: {}", key, value);
+      return null;
+    }
+  }
+
+  /**
+   * Map에서 문자열 리스트를 안전하게 추출합니다.
+   */
+  @SuppressWarnings("unchecked")
+  private List<String> safeGetStringList(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    if (value instanceof List) {
+      try {
+        return (List<String>) value;
+      } catch (ClassCastException e) {
+        log.warn("리스트 타입 캐스팅 실패 - key: {}, value: {}", key, value);
+        return null;
       }
+    }
+    return null;
+  }
 
-      // options 파싱 (AI 서버에서 "options" 필드로 보냄)
-      @SuppressWarnings("unchecked")
-      List<String> options = (List<String>) responseMap.get("options");
-      response.setTemplateOptions(options);
+  /**
+   * Map에서 TemplateState를 안전하게 파싱합니다.
+   */
+  private TemplateState safeParseState(Map<String, Object> map, String key) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> stateMap = (Map<String, Object>) map.get(key);
 
-      // AI 응답의 state 정보 파싱
-      @SuppressWarnings("unchecked")
-      Map<String, Object> aiStateMap = (Map<String, Object>) responseMap.get("state");
+    TemplateState state = new TemplateState();
 
-      TemplateState state = new TemplateState();
+    if (stateMap != null) {
+      try {
+        state.setNextAction(safeGetString(stateMap, "next_action"));
 
-      if (aiStateMap != null) {
-        // AI state에서 직접 정보 추출
-        state.setNextAction((String) aiStateMap.get("next_action"));
-
-        // template_pipeline_state에서 상세 정보 추출
         @SuppressWarnings("unchecked")
-        Map<String, Object> pipelineState =
-            (Map<String, Object>) aiStateMap.get("template_pipeline_state");
+        Map<String, Object> pipelineState = (Map<String, Object>) stateMap.get("template_pipeline_state");
         state.setTemplatePipelineState(pipelineState);
 
         if (pipelineState != null) {
-          state.setOriginalRequest((String) pipelineState.get("original_request"));
+          state.setOriginalRequest(safeGetString(pipelineState, "original_request"));
         }
+      } catch (Exception e) {
+        log.warn("State 파싱 중 오류 발생: {}", e.getMessage());
       }
-
-      response.setState(state);
-
-      log.info(
-          "AI 응답 파싱 완료: message={}, next_action={}, original_request={}",
-          response.getMessage(),
-          state.getNextAction(),
-          state.getOriginalRequest());
-
-      return response;
-    } catch (Exception e) {
-      log.error("AI 응답 파싱 실패: {}", e.getMessage(), e);
-      // 파싱 실패 시 기본 응답 반환
-      TemplateCreateResponseDto fallbackResponse = new TemplateCreateResponseDto();
-      fallbackResponse.setMessage("AI 응답 처리 중 오류가 발생했습니다.");
-      return fallbackResponse;
     }
+
+    return state;
+  }
+
+  /**
+   * 파싱 실패 시 반환할 기본 응답을 생성합니다.
+   */
+  private TemplateCreateResponseDto createFallbackResponse() {
+    TemplateCreateResponseDto fallback = new TemplateCreateResponseDto();
+    fallback.setMessage("AI 응답 처리 중 오류가 발생했습니다.");
+    fallback.setState(new TemplateState()); // 빈 state 객체
+    return fallback;
   }
 
   /**


### PR DESCRIPTION
## PR 종류
- [X] 기능 개선
- [ ] 새로운 기능
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
  1. TemplateState.toMap() 메서드 개선
  - 위치: src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java:57
  - 변경내용:
    - 기존 필드(step, original_request)는 기본값 제공으로 하위 호환성 보장
    - 새 필드 6개는 null 체크 후 null이 아닐 때만 AI 서버로 전송
    - AI 서버 에러 방지를 위한 null 필터링 로직 추가

  2. TemplateService.parseAiResponse() 메서드 안전성 강화
  - 위치: src/main/java/org/fastcampus/jober/template/service/TemplateService.java:80
  - 변경내용:
    - 안전한 타입 캐스팅을 위한 헬퍼 메서드 추가 (safeGetString, safeConvertToJson, safeGetStringList, safeParseState)
    - JSON 변환 실패 시 안전한 fallback 처리
    - 모든 파싱 과정에서 null 안전성 보장
    - 파싱 실패 시 기본 응답 반환으로 서비스 안정성 향상

## 관련 이슈- 관련된 이슈 번호를 적어주세요 (#28 )

## 체크리스트- [ ] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?

## 기타
테스트 시나리오 1: 프론트엔드가 기존처럼 2개 필드만 보내는 경우
  // 프론트엔드 요청
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": {
      "step": "initial",
      "original_request": "마케팅용 카카오톡 템플릿"
    }
  }

  // 백엔드에서 AI 서버로 전송 (수정 후)
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": {
      "step": "initial",
      "original_request": "마케팅용 카카오톡 템플릿"
      // null 필드들은 제외됨!
    }
  }

  테스트 시나리오 2: 프론트엔드가 state null로 보내는 경우
  // 프론트엔드 요청
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": null
  }

  // 백엔드에서 AI 서버로 전송 (TemplateCreateRequestDto.toRequestBody()에서 처리)
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": {}  // 빈 객체로 변환
  }

테스트 시나리오 3: 향후 프론트엔드가 새 필드를 추가하는 경우
  // 프론트엔드 요청 (새 필드 포함)
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": {
      "step": "initial",
      "original_request": "마케팅용 카카오톡 템플릿",
      "selected_style": "기본형"  // 새 필드 추가
    }
  }

  // 백엔드에서 AI 서버로 전송 (자동으로 처리됨)
  {
    "message": "마케팅용 카카오톡 템플릿",
    "state": {
      "step": "initial",
      "original_request": "마케팅용 카카오톡 템플릿",
      "selected_style": "기본형"  // 포함됨
      // 여전히 null인 필드들은 제외됨
    }
  }
