### PR TITLE
hotfix: 템플릿 생성 API null 처리 개선

### DIFF
--- a/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
+++ b/src/main/java/org/fastcampus/jober/template/dto/request/TemplateState.java
@@ -53,19 +53,37 @@ public class TemplateState {
     
     /**
      * AI Flask 서버가 기대하는 Map 형태로 변환합니다.
-     * 
+     * 하위 호환성을 보장하기 위해 기존 필드는 기본값으로, 새 필드는 null이 아닐 때만 포함합니다.
+     *
      * @return Map 형태의 상태 정보
      */
     public Map<String, Object> toMap() {
         Map<String, Object> stateMap = new HashMap<>();
-        stateMap.put("step", this.step);
-        stateMap.put("original_request", this.originalRequest);
-        stateMap.put("selected_style", this.selectedStyle);
-        stateMap.put("selected_template", this.selectedTemplate);
-        stateMap.put("validation_result", this.validationResult);
-        stateMap.put("correction_attempts", this.correctionAttempts);
-        stateMap.put("next_action", this.nextAction);
-        stateMap.put("template_pipeline_state", this.templatePipelineState);
+
+        // 기존 필드 (하위 호환성 보장 - 기본값 제공)
+        stateMap.put("step", this.step != null ? this.step : "initial");
+        stateMap.put("original_request", this.originalRequest != null ? this.originalRequest : "");
+
+        // 새 필드들 (null이 아닐 때만 추가 - AI 서버 에러 방지)
+        if (this.selectedStyle != null) {
+            stateMap.put("selected_style", this.selectedStyle);
+        }
+        if (this.selectedTemplate != null) {
+            stateMap.put("selected_template", this.selectedTemplate);
+        }
+        if (this.validationResult != null) {
+            stateMap.put("validation_result", this.validationResult);
+        }
+        if (this.correctionAttempts != null) {
+            stateMap.put("correction_attempts", this.correctionAttempts);
+        }
+        if (this.nextAction != null) {
+            stateMap.put("next_action", this.nextAction);
+        }
+        if (this.templatePipelineState != null) {
+            stateMap.put("template_pipeline_state", this.templatePipelineState);
+        }
+
         return stateMap;
     }
 }


### PR DESCRIPTION
## Summary
- 템플릿 생성 API에서 null 값으로 인한 AI 서버 에러 방지
- 프론트엔드 하위 호환성 보장 (기존 2필드만 전송해도 정상 동작)

## Changes
- `TemplateState.toMap()`: null 필드는 제외하여 전송하여 AI 서버 에러 방지
- `TemplateService.parseAiResponse()`: 안전한 파싱 메서드로 null 처리 강화
- 기존 필드(`step`, `original_request`)는 기본값 제공으로 하위 호환성 보장

## Test plan
- [ ] 기존 프론트엔드에서 2필드만 전송해도 정상 동작 확인
- [ ] AI 서버 통신 시 null 에러 발생하지 않음 확인
- [ ] 새로운 8필드 구조도 정상 동작 확인