### PR TITLE
hotfix: 템플릿 API 경로 충돌 해결

### DIFF
--- a/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
+++ b/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
@@ -42,7 +42,40 @@ import java.util.List;
 public class TemplateController {
     
     private final TemplateService templateService;
-    
+
+    /**
+     * AI를 통한 템플릿 생성 요청 API
+     * 사용자의 메시지를 받아서 AI Flask 서버로 전달하고,
+     * 구조화된 템플릿 응답을 반환합니다.
+     *
+     * @param request 템플릿 생성 요청 DTO (사용자 메시지와 AI 세션 상태 포함)
+     * @return AI가 생성한 구조화된 템플릿 응답 DTO
+     */
+    @Operation(
+        summary = "AI 템플릿 생성 요청",
+        description = "사용자 메시지를 기반으로 AI가 템플릿을 생성합니다. " +
+                     "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하고 구조화된 응답을 반환합니다."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "AI 템플릿 생성 성공",
+        content = @Content(schema = @Schema(implementation = TemplateCreateResponseDto.class))
+    )
+    @PostMapping("/create-template")
+    public ResponseEntity<TemplateCreateResponseDto> createTemplate(
+            @org.springframework.web.bind.annotation.RequestBody TemplateCreateRequestDto request) {
+
+        log.info("템플릿 생성 요청 수신 - 사용자 메시지: {}, state: {}", request.getMessage(), request.getState());
+
+        // TemplateService를 통해 AI Flask 서버로 요청 전달
+        TemplateCreateResponseDto aiResponse = templateService.createTemplate(request);
+
+        log.info("AI Flask 서버로부터 응답 수신 완료");
+
+        return ResponseEntity.ok(aiResponse);
+
+    }
+
     /**
      * GET 방식으로 spaceId를 받아서 해당 spaceId의 템플릿 title들을 조회하는 API
      * @param spaceId 스페이스 ID
@@ -124,38 +157,6 @@ public class TemplateController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(template);
-    }
-     /**
-     * AI를 통한 템플릿 생성 요청 API
-     * 사용자의 메시지를 받아서 AI Flask 서버로 전달하고, 
-     * 구조화된 템플릿 응답을 반환합니다.
-     * 
-     * @param request 템플릿 생성 요청 DTO (사용자 메시지와 AI 세션 상태 포함)
-     * @return AI가 생성한 구조화된 템플릿 응답 DTO
-     */
-    @Operation(
-        summary = "AI 템플릿 생성 요청", 
-        description = "사용자 메시지를 기반으로 AI가 템플릿을 생성합니다. " +
-                     "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하고 구조화된 응답을 반환합니다."
-    )
-    @ApiResponse(
-        responseCode = "200", 
-        description = "AI 템플릿 생성 성공",
-        content = @Content(schema = @Schema(implementation = TemplateCreateResponseDto.class))
-    )
-    @PostMapping("/create-template")
-    public ResponseEntity<TemplateCreateResponseDto> createTemplate(
-            @org.springframework.web.bind.annotation.RequestBody TemplateCreateRequestDto request) {
-        
-        log.info("템플릿 생성 요청 수신 - 사용자 메시지: {}, state: {}", request.getMessage(), request.getState());
-        
-        // TemplateService를 통해 AI Flask 서버로 요청 전달
-        TemplateCreateResponseDto aiResponse = templateService.createTemplate(request);
-        
-        log.info("AI Flask 서버로부터 응답 수신 완료");
-        
-        return ResponseEntity.ok(aiResponse);
-
     }
 
     // @PatchMapping("/{templateId}/space/{spaceId}")


### PR DESCRIPTION
## Summary
- 템플릿 생성 API 경로 충돌 문제 해결
- Spring Boot 라우팅 순서 최적화

## Issue
```
POST /template/create-template 요청이 
GET /template/{spaceId} 경로에 먼저 매칭되어
"create-template"이 spaceId로 잘못 인식되는 문제
```

## Solution
- `@PostMapping("/create-template")`을 `@GetMapping("/{spaceId}")` 위로 이동
- 더 구체적인 경로가 먼저 매칭되도록 순서 변경

## Test plan
- [ ] POST /template/create-template API 정상 동작 확인
- [ ] GET /template/{spaceId} API 정상 동작 확인
- [ ] 경로 충돌 에러 해결 확인