### PR TITLE
fix : TemplateController 라우팅 충돌(경로 순서) 해결 /{spaceId} /create-template 순서변경

### DIFF
--- a/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
+++ b/src/main/java/org/fastcampus/jober/template/controller/TemplateController.java
@@ -40,6 +40,34 @@ public class TemplateController {
   private final TemplateService templateService;
 
   /**
+   * AI를 통한 템플릿 생성 요청 API 사용자의 메시지를 받아서 AI Flask 서버로 전달하고, 구조화된 템플릿 응답을 반환합니다.
+   *
+   * @param request 템플릿 생성 요청 DTO (사용자 메시지와 AI 세션 상태 포함)
+   * @return AI가 생성한 구조화된 템플릿 응답 DTO
+   */
+  @Operation(
+      summary = "AI 템플릿 생성 요청",
+      description =
+          "사용자 메시지를 기반으로 AI가 템플릿을 생성합니다. " + "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하고 구조화된 응답을 반환합니다.")
+  @ApiResponse(
+      responseCode = "200",
+      description = "AI 템플릿 생성 성공",
+      content = @Content(schema = @Schema(implementation = TemplateCreateResponseDto.class)))
+  @PostMapping("/create-template")
+  public ResponseEntity<TemplateCreateResponseDto> createTemplate(
+      @org.springframework.web.bind.annotation.RequestBody TemplateCreateRequestDto request) {
+
+    log.info("템플릿 생성 요청 수신 - 사용자 메시지: {}, state: {}", request.getMessage(), request.getState());
+
+    // TemplateService를 통해 AI Flask 서버로 요청 전달
+    TemplateCreateResponseDto aiResponse = templateService.createTemplate(request);
+
+    log.info("AI Flask 서버로부터 응답 수신 완료");
+
+    return ResponseEntity.ok(aiResponse);
+  }
+
+  /**
    * GET 방식으로 spaceId를 받아서 해당 spaceId의 템플릿 title들을 조회하는 API
    *
    * @param spaceId 스페이스 ID
@@ -95,34 +123,6 @@ public class TemplateController {
       return ResponseEntity.notFound().build();
     }
     return ResponseEntity.ok(template);
-  }
-
-  /**
-   * AI를 통한 템플릿 생성 요청 API 사용자의 메시지를 받아서 AI Flask 서버로 전달하고, 구조화된 템플릿 응답을 반환합니다.
-   *
-   * @param request 템플릿 생성 요청 DTO (사용자 메시지와 AI 세션 상태 포함)
-   * @return AI가 생성한 구조화된 템플릿 응답 DTO
-   */
-  @Operation(
-      summary = "AI 템플릿 생성 요청",
-      description =
-          "사용자 메시지를 기반으로 AI가 템플릿을 생성합니다. " + "리액트에서 사용자 입력을 받아 AI Flask 서버로 전달하고 구조화된 응답을 반환합니다.")
-  @ApiResponse(
-      responseCode = "200",
-      description = "AI 템플릿 생성 성공",
-      content = @Content(schema = @Schema(implementation = TemplateCreateResponseDto.class)))
-  @PostMapping("/create-template")
-  public ResponseEntity<TemplateCreateResponseDto> createTemplate(
-      @org.springframework.web.bind.annotation.RequestBody TemplateCreateRequestDto request) {
-
-    log.info("템플릿 생성 요청 수신 - 사용자 메시지: {}, state: {}", request.getMessage(), request.getState());
-
-    // TemplateService를 통해 AI Flask 서버로 요청 전달
-    TemplateCreateResponseDto aiResponse = templateService.createTemplate(request);
-
-    log.info("AI Flask 서버로부터 응답 수신 완료");
-
-    return ResponseEntity.ok(aiResponse);
   }
 
   // @PatchMapping("/{templateId}/space/{spaceId}")


### PR DESCRIPTION
## PR 종류
- [ ] 기능 개선
- [ ] 새로운 기능
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
충돌없이 라우팅 순서 수정 적용 
    - @PostMapping("/create-template") → 먼저 매칭 (구체적 경로)
    - @GetMapping("/{spaceId}") → 나중 매칭 (넓은 경로)

## 관련 이슈- 관련된 이슈 번호를 적어주세요 (#48 )

## 체크리스트- [ ] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?
